### PR TITLE
Update to libnpm@^3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "libnpm": "^2.0.1",
+    "libnpm": "^3.0.1",
     "pacote": "^9.5.0",
     "read-pkg": "^5.1.1",
     "yargs": "^13.2.2"


### PR DESCRIPTION
This package depends on `libnpm@^2.0.1`, which itself depends on `npm-registry-fetch@^3.8.0`. The npm-registry-fetch package has a security vulnerability in it for versions prior to 4.0.0 (see https://github.com/advisories/GHSA-jmqm-f2gx-4fjv).

Updating the dependency to `libnpm@^3.0.1` resolves this as libnpm has already updated their dependency on npm-registry-fetch.

If possible, it would be good if this could be a patch version bump (i.e. 0.1.1) so that other packages depending on pkg-add-deps don't need to update their own dependency pins (as long as they're using carat pins). I think this makes sense with semantic versioning anyway since there is no functionality change for this package.

Note: I haven't tested this as I'm not familiar with the package. However the libnpm update looks quite safe as there's no code change, only changes to its dependencies.